### PR TITLE
Update KDE runtime to 5.15-23.08

### DIFF
--- a/io.github.trevorsandy.LPub3D.json
+++ b/io.github.trevorsandy.LPub3D.json
@@ -1,7 +1,7 @@
 {
   "id": "io.github.trevorsandy.LPub3D",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.15-21.08",
+  "runtime-version": "5.15-23.08",
   "sdk": "org.kde.Sdk",
   "command": "lpub3d24",
   "rename-icon": "lpub3d",

--- a/xvfb-module/xvfb.json
+++ b/xvfb-module/xvfb.json
@@ -13,14 +13,13 @@
     "--prefix=/app/build_staging/xvfb",
     "-Dxorg=true",
     "-Dxvfb=true",
-    "-Dhal=false",
-    "-Dxwayland=false"
+    "-Dhal=false"
   ],
   "sources": [
     {
       "type": "archive",
-      "url": "https://gitlab.freedesktop.org/xorg/xserver/-/archive/xorg-server-1.20.13/xserver-xorg-server-1.20.13.tar.bz2",
-      "sha256": "a0fb4d8ed5edb69d66242d817bb5cd1cf4e21badd3957d8431e68d9bc57d29ba"
+      "url": "https://gitlab.freedesktop.org/xorg/xserver/-/archive/xorg-server-21.1.9/xserver-xorg-server-21.1.9.tar.bz2",
+      "sha256": "6039a5f77e3936a51fac7eb17b719f5e97c846c24094555c482efd648b9479c0"
     },
     {
       "type": "file",
@@ -31,6 +30,17 @@
     "install -c -m 755 ${FLATPAK_BUILDER_BUILDDIR}/xvfb-run /app/build_staging/xvfb/bin/xvfb-run"
   ],
   "modules": [
+    {
+      "name": "libxcvt",
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://gitlab.freedesktop.org/xorg/lib/libxcvt/-/archive/libxcvt-0.1.2/libxcvt-libxcvt-0.1.2.tar.bz2",
+          "sha256": "590e5a6da87ace7aa7857026b207a2c4d378620035441e20ea97efedd15d6d4a"
+        }
+      ]
+    },
     {
       "name": "xvfb-libXmu",
       "buildsystem": "simple",


### PR DESCRIPTION
The 21.08 Freedesktop runtime this Flatpak uses is now end-of-life, so I'm opening this PR to update it to 23.08 (still using the KDE runtime version 5.15).