### PR TITLE
Update assets as the old one are gone

### DIFF
--- a/io.github.trevorsandy.LPub3D.json
+++ b/io.github.trevorsandy.LPub3D.json
@@ -83,7 +83,7 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://archive.mesa3d.org/mesa-20.2.6.tar.xz",
+          "url": "https://archive.mesa3d.org/older-versions/20.x/mesa-20.2.6.tar.xz",
           "sha256": "f12ca3c6c622f11cd79ad66b4220f04514fa96f795062fe92a37339ab19885db"
         }
       ]
@@ -103,14 +103,14 @@
         {
           "type": "file",
           "dest-filename": "complete.zip",
-          "url": "https://github.com/trevorsandy/lpub3d_libs/releases/download/v1.0.1/complete-25-02.zip",
-          "sha256": "a4ab15366d22ae0589901ec15bcc465fd5bb5b6057661b91b89b810f98a56c06"
+          "url": "https://github.com/trevorsandy/lpub3d_libs/releases/download/v1.0.1/complete-25-09.zip",
+          "sha256": "13703b0eb55575b88b6a677c7b33c394246010af31d74adbc38ea74abc839633"
         },
         {
           "type": "file",
           "dest-filename": "lpub3dldrawunf.zip",
-          "url": "https://github.com/trevorsandy/lpub3d_libs/releases/download/v1.0.1/lpub3dldrawunf-25-03-15.zip",
-          "sha256": "a22da755a9c10cecf37928f4c951be00be9149146914de2a2b7a526906fdfd0e"
+          "url": "https://github.com/trevorsandy/lpub3d_libs/releases/download/v1.0.1/lpub3dldrawunf-25-09-04.zip",
+          "sha256": "43875f5b31f9f1bb309f36b0349eb823d50ef771f4283e792283bae32b7389d9"
         },
         {
           "type": "file",


### PR DESCRIPTION
Removing tarballs from release isn't nice. It break builds.